### PR TITLE
Trying to get puush Recent Uploads to work

### DIFF
--- a/app.js
+++ b/app.js
@@ -317,7 +317,7 @@ http.createServer(function (request, response)
 					fs.readFile(uploadPath + doc.name, 'binary', function (err, file)
 					{
 						if (err)
-						{        
+						{
 							response.writeHead(500, { 'Content-Type': 'text/html' });
 							response.end('<h1>500 Internal Server Error</h1>');
 							return;

--- a/app.js
+++ b/app.js
@@ -281,15 +281,6 @@ function handleRegister(req, res)
 	res.end();
 }
 
-function encode_base10(string)
-{
-	var number = "";
-	var length = string.length;
-	for (var i = 0; i < length; i++)
-		number += string.charCodeAt(i).toString(10);
-	return number;
-}
-
 function format_date(d)
 {
 	return d.toISOString().replace("T", " ").split(".")[0];
@@ -441,7 +432,7 @@ http.createServer(function (request, response)
 					var output = "0\n";
 					result.map( function(item)
 					{
-						out = encode_base10(item["shortname"]) + ",";
+						out = "5623457,";
 						out += format_date(item["ts"]) + ",";
 						out += uploadedUrl + item["shortname"] + ",";
 						out += item["name"] + ",1337,0\n";


### PR DESCRIPTION
Don't pull this into master, still WIP.

I'm trying to get the Recent Uploads context menu to work by implementing /api/hist, but I can't figure it out. I have a feeling it's something to do with the item ID, which may be sequential on puush.me's server, I don't know why the items aren't showing up in puush's menu.

Here's what puush.me sends from /api/hist:

    0
    104248997,2014-02-20 23:14:01,http://puu.sh/73pVr.png,ss (2014-02-20 at 11.13.02).png,2,0
    104247683,2014-02-20 23:07:27,http://puu.sh/73pAf.png,ss (2014-02-20 at 11.06.28).png,1,0
    102044795,2014-02-13 13:25:55,http://puu.sh/6UavN.png,ss (2014-02-13 at 01.25.01).png,1,0
    etc

And here's what this change sends:

    0
    11348101109,2014-02-20 18:39:21,http://s.blha303.com.au/q0em,clipboard_1259.txt,1337,0
    7811510284,2014-02-20 18:15:49,http://s.blha303.com.au/NsfT,ss (2014-02-21 at 02.12.18).png,1337,0
    5711481108,2014-02-20 18:05:17,http://s.blha303.com.au/9rQl,ss (2014-02-21 at 02.01.48).png,1337,0
    etc

The number is produced by the encode_base10 function I made, but maybe it's too long. Maybe puush doesn't like numbers larger than MAX_INT. I'm going to try more things, just thought I'd put this up here so others can have a crack at it.